### PR TITLE
Use composer.json `testing` keyword to tag this as require-dev package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "gyro/phake-attributes",
     "description": "A #[Mock] attribute for Phake inside PHPUnit and helpers.",
     "license": "MIT",
+    "keywords": ["testing"],
     "autoload": {
         "psr-4": {
             "Gyro\\PhakeAttributes\\": "src/"


### PR DESCRIPTION
This keyword will ensure users are prompted to use require-dev when installing this package. 

See https://getcomposer.org/doc/04-schema.md#keywords